### PR TITLE
feat(CBP-51359): Clear Asset Store Changes Commit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -87,7 +87,7 @@ For more information, refer to the link:https://cmake.org/cmake/help/book/master
 | The number of *Low* security findings discovered during the scan.
 
 | `policy-subject`
-| String
+| JSON
 | A JSON value containing the details about the vulnerability scan summary and details.
 
 |===

--- a/action.yaml
+++ b/action.yaml
@@ -74,7 +74,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -87,7 +87,7 @@ runs:
         INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -122,7 +122,7 @@ runs:
       run: /app/plugin-sonarqube-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yaml
+++ b/action.yaml
@@ -61,8 +61,20 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Generate sha and ref 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:b76b5f7a853e1bca39417c87799b2fbbdd03ecb3
+    - name: Clear asset store for scan
+      uses: docker://alpine:latest
+      shell: sh
+      run: |
+        if [ -d "$CLOUDBEES_WORKSPACE/store" ]; then
+          find $CLOUDBEES_WORKSPACE/store -mindepth 2 -maxdepth 2 \
+            -type d ! -name "discovered-profile-findings" \
+            -exec rm -rf {} +
+          rm -rf $CLOUDBEES_WORKSPACE/store/binary-assets
+          rm -rf $CLOUDBEES_WORKSPACE/store/request
+        fi
+
+    - name: Generate sha and ref
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -75,7 +87,7 @@ runs:
         INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:b76b5f7a853e1bca39417c87799b2fbbdd03ecb3
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -110,7 +122,7 @@ runs:
       run: /app/plugin-sonarqube-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:b76b5f7a853e1bca39417c87799b2fbbdd03ecb3
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request introduces a few updates to the vulnerability scanning workflow and its documentation. The main changes include improving the asset store cleanup process before scans, updating the Docker image version for the `assets-plugin-chain-utils` utility, and clarifying the expected data type for the `policy-subject` output.

**Workflow improvements:**

* Added a new step in `action.yaml` to clear specific directories from the asset store before running a scan, ensuring a clean environment for each scan execution.

* Updated the Docker image version for the `assets-plugin-chain-utils` utility in three workflow steps (`Generate sha and ref`, `Generate reference files`, and `Complete execution plan`) to use a newer image (`8ffcff74b5e47eb284c2b137a00b839db558fde1`). This ensures consistency and may include bug fixes or performance improvements from the updated image. [[1]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dR64-R77) [[2]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL78-R90) [[3]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL113-R125)

**Documentation update:**

* Changed the documented type of the `policy-subject` output in `README.adoc` from `String` to `JSON`, clarifying that it provides a structured JSON value with vulnerability scan details.