### PR TITLE
feat(CBP-52533): Update action.yaml to use new image tag

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -74,7 +74,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -87,7 +87,7 @@ runs:
         INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -122,7 +122,7 @@ runs:
       run: /app/plugin-sonarqube-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request updates the `action.yaml` workflow to use a newer version of the `assets-plugin-chain-utils` Docker image in three different steps. The main goal is to ensure that all workflow steps use the latest version of the utility image for improved reliability or new features.

**Dependency update:**

* Updated the `assets-plugin-chain-utils` Docker image from version `d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d` to `267bff4ae4e4f12d036c5593ce1864301185c722` in the following workflow steps:
  - "Generate sha and ref"
  - "Generate reference files"
  - "Complete execution plan"