### PR TITLE
fix(cbp-52712): bump assets-plugin-chain-utils to b7c296b5

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -74,7 +74,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:b7c296b5efb441752869a1f9e2e57a259f9cb6ce
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -87,7 +87,7 @@ runs:
         INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files 
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:b7c296b5efb441752869a1f9e2e57a259f9cb6ce
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -122,7 +122,7 @@ runs:
       run: /app/plugin-sonarqube-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:b7c296b5efb441752869a1f9e2e57a259f9cb6ce
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
## Summary
- Bumps \`assets-plugin-chain-utils\` from \`267bff4a\` → \`b7c296b5\`
- CBP-52712: suppresses \`sast_scan\` PolicySubject emission; derivation now sourced from \`vulnerability_scan\` via CBP-52704

Jira: [CBP-52712](https://cloudbees.atlassian.net/browse/CBP-52712)

## Test plan
- [ ] CI passes
- [ ] Scan workflow produces no standalone \`sast_scan\` subject

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CBP-52712]: https://cloudbees.atlassian.net/browse/CBP-52712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ